### PR TITLE
fix: use correct platform name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tested with Home Assistant 2021.12.10.
 
 ```yaml
 sensor:
-  - platform: prometheus_query
+  - platform: prometheus_sensor
     url: http://localhost:9090
     queries:
       - name: Energy usage


### PR DESCRIPTION
Hi,

i noticed a simple error in the example. it works with `platform: prometheus_sensor`