### PR TITLE
Allow specifying unique_id and native_value

### DIFF
--- a/custom_components/prometheus_sensor/sensor.py
+++ b/custom_components/prometheus_sensor/sensor.py
@@ -30,15 +30,17 @@ DEFAULT_URL = "http://localhost:9090"
 CONF_QUERIES = "queries"
 CONF_EXPR = "expr"
 CONF_STATE_CLASS = "state_class"
+CONF_UNIQUE_ID = "unique_id"
+CONF_NATIVE_VALUE = "native_value"
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 _LOGGER = logging.getLogger(__name__)
 
 _QUERY_SCHEMA = vol.Schema(
     {
-        vol.Required(
-            CONF_NAME,
-        ): cv.string,
+        vol.Required(CONF_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_NATIVE_VALUE): cv.string,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
         vol.Required(CONF_EXPR): cv.string,
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
@@ -117,6 +119,8 @@ class PrometheusSensor(SensorEntity):
         self._prometheus: Prometheus = prometheus
 
         self._attr_name = query.get(CONF_NAME)
+        self._attr_unique_id = query.get(CONF_UNIQUE_ID)
+        self._attr_native_value = query.get(CONF_NATIVE_VALUE)
         self._attr_native_unit_of_measurement = query.get(CONF_UNIT_OF_MEASUREMENT)
         self._attr_state_class = query.get(CONF_STATE_CLASS)
         self._attr_device_class = query.get(CONF_DEVICE_CLASS)

--- a/custom_components/prometheus_sensor/sensor.py
+++ b/custom_components/prometheus_sensor/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_URL,
+    CONF_UNIQUE_ID,
     STATE_PROBLEM,
     STATE_UNKNOWN,
 )
@@ -30,7 +31,6 @@ DEFAULT_URL = "http://localhost:9090"
 CONF_QUERIES = "queries"
 CONF_EXPR = "expr"
 CONF_STATE_CLASS = "state_class"
-CONF_UNIQUE_ID = "unique_id"
 CONF_NATIVE_VALUE = "native_value"
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 


### PR DESCRIPTION
Hi! Thanks for building this neat little project.

After I have integrated it with my system I had two issues:
* Home Assistant was complaining that it couldn't manage the new sensor because it didn't have a unique ID
* I wasn't able to use numerical comparisons on an untyped value

To fix those issues I have added optional `unique_id` and `native_value`  attributes to query entities. I've tried this change and it works well for me.