### PR TITLE
fix issue where the initial prometheus query would fail and never recover

### DIFF
--- a/custom_components/prometheus_sensor/binary_sensor.py
+++ b/custom_components/prometheus_sensor/binary_sensor.py
@@ -74,9 +74,7 @@ async def async_setup_platform(
             )
             for query in config[CONF_QUERIES]
         ],
-        # ensure the entities are added first so if the first poll fails unexpectedly
-        # the entity will still be created and polling will retry
-        update_before_add=False,
+        update_before_add=True,
     )
 
 

--- a/custom_components/prometheus_sensor/sensor.py
+++ b/custom_components/prometheus_sensor/sensor.py
@@ -77,9 +77,7 @@ async def async_setup_platform(
             )
             for query in config[CONF_QUERIES]
         ],
-        # ensure the entities are added first so if the first poll fails unexpectedly
-        # the entity will still be created and polling will retry
-        update_before_add=False,
+        update_before_add=True,
     )
 
 


### PR DESCRIPTION
Hi, thanks for this project.

I’ve got an issue where the Prometheus instance this component polls runs on the same server, and the service is resolved via DNS. This becomes a problem after a VM restart: the Prometheus service may not be available yet, causing DNS resolution to fail. When that happens, the Prometheus Sensor entity is never registered and the query is never retried.

This PR includes two fixes for this problem:
1. Catch HTTP client errors and report them as a problem, instead of letting the OSError bubble up.
2. Set `update_before_add` to `False`, so the sensor is created in an `Unknown` state before the first query runs. That way, even if an exception occurs, Home Assistant will still retry the query later.

Thanks!


---


Original stack trace looks something like this:
```
2026-01-25 10:28:53.405 ERROR (MainThread) [homeassistant.helpers.entity] Update for sensor.kitchen_temperature fails
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1268, in _wrap_create_connection
    sock = await aiohappyeyeballs.start_connection(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/aiohappyeyeballs/impl.py", line 122, in start_connection
    raise first_exception
  File "/usr/local/lib/python3.13/site-packages/aiohappyeyeballs/impl.py", line 73, in start_connection
    sock = await _connect_sock(
           ^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/aiohappyeyeballs/impl.py", line 208, in _connect_sock
    await loop.sock_connect(sock, address)
  File "/usr/local/lib/python3.13/asyncio/selector_events.py", line 641, in sock_connect
    return await fut
           ^^^^^^^^^
  File "/usr/local/lib/python3.13/asyncio/selector_events.py", line 681, in _sock_connect_cb
    raise OSError(err, f'Connect call failed {address}')
ConnectionRefusedError: [Errno 111] Connect call failed ('10.43.250.201', 8429)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 963, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1314, in async_device_update
    await self.async_update()
  File "/config/custom_components/prometheus_sensor/sensor.py", line 110, in async_update
    result: QueryResult = await self._prometheus.query(self._expression)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/prometheus_sensor/__init__.py", line 29, in query
    response = await self._session.get(self._url, params={"query": expr})
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client.py", line 770, in _request
    resp = await handler(req)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client.py", line 725, in _connect_and_send_request
    conn = await self._connector.connect(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        req, traces=traces, timeout=real_timeout
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 642, in connect
    proto = await self._create_connection(req, traces, timeout)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1209, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1581, in _create_direct_connection
    raise last_exc
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1550, in _create_direct_connection
    transp, proto = await self._wrap_create_connection(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/connector.py", line 1291, in _wrap_create_connection
    raise client_error(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host vmsingle-vm-stack-victoria-metrics-k8s-stack.vm.svc.cluster.local:8429 ssl:default [Connect call failed ('10.43.250.201', 8429)]
```

With the new exception capture, it now looks like this in the logs:

```
2026-01-25 10:29:37.967 ERROR (MainThread) [custom_components.prometheus_sensor] HTTP request failed: Cannot connect to host vmsingle-vm-stack-victoria-metrics-k8s-stack.vm.svc.cluster.local:8429 ssl:default [Connect call failed ('10.43.250.201', 8429)]
```