### PR TITLE
Add support for reloading of YAML configuration

### DIFF
--- a/custom_components/prometheus_sensor/__init__.py
+++ b/custom_components/prometheus_sensor/__init__.py
@@ -1,13 +1,28 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 import logging
-from typing import Final, Optional
+from typing import TYPE_CHECKING, Final, Optional
 from urllib.parse import urljoin
 
 import aiohttp
 
 from homeassistant.const import STATE_PROBLEM, STATE_UNKNOWN
+from homeassistant.helpers.reload import async_setup_reload_service
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN, PLATFORMS
 
 _LOGGER: Final = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the prometheus-sensor integration."""
+    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
+    return True
 
 
 @dataclass(frozen=True)

--- a/custom_components/prometheus_sensor/const.py
+++ b/custom_components/prometheus_sensor/const.py
@@ -1,6 +1,9 @@
 from datetime import timedelta
 from typing import Final
 
+DOMAIN = "prometheus_sensor"
+PLATFORMS = ["binary_sensor", "sensor"]
+
 # Match the default scrape_interval in Prometheus
 SCAN_INTERVAL: Final = timedelta(seconds=15)
 


### PR DESCRIPTION
This allows users to hot reload the configuration through Developer
Tools rather than having to fully restart Home Assistant in order for
changes to be reflected.