### PR TITLE
feat: add support for custom headers in Prometheus requests

### DIFF
--- a/custom_components/prometheus_sensor/__init__.py
+++ b/custom_components/prometheus_sensor/__init__.py
@@ -34,15 +34,20 @@ class QueryResult:
 class Prometheus:
     """Wrapper for Prometheus API Requests."""
 
-    def __init__(self, url: str, session: aiohttp.ClientSession) -> None:
+    def __init__(
+        self, url: str, session: aiohttp.ClientSession, headers: dict | None = None
+    ) -> None:
         """Initialize the Prometheus API wrapper."""
         self._session = session
         self._url = urljoin(f"{url}/", "api/v1/query")
+        self._headers = headers
 
     async def query(self, expr: str) -> QueryResult:
         """Query expression response."""
         try:
-            response = await self._session.get(self._url, params={"query": expr})
+            response = await self._session.get(
+                self._url, params={"query": expr}, headers=self._headers
+            )
         except aiohttp.ClientError as error:
             _LOGGER.error("Error querying %s: %s", self._url, error)
             return QueryResult(error=STATE_PROBLEM)

--- a/custom_components/prometheus_sensor/__init__.py
+++ b/custom_components/prometheus_sensor/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING, Final, Optional
@@ -35,7 +36,10 @@ class Prometheus:
     """Wrapper for Prometheus API Requests."""
 
     def __init__(
-        self, url: str, session: aiohttp.ClientSession, headers: dict | None = None
+        self,
+        url: str,
+        session: aiohttp.ClientSession,
+        headers: Mapping[str, str] | None = None,
     ) -> None:
         """Initialize the Prometheus API wrapper."""
         self._session = session

--- a/custom_components/prometheus_sensor/binary_sensor.py
+++ b/custom_components/prometheus_sensor/binary_sensor.py
@@ -31,7 +31,13 @@ if TYPE_CHECKING:
 
     from . import QueryResult
 
-from .const import CONF_EXPR, CONF_QUERIES, DEFAULT_URL, SCAN_INTERVAL as SCAN_INTERVAL
+from .const import (
+    CONF_EXPR,
+    CONF_HEADERS,
+    CONF_QUERIES,
+    DEFAULT_URL,
+    SCAN_INTERVAL as SCAN_INTERVAL,
+)
 
 _QUERY_SCHEMA: Final = vol.Schema(
     {
@@ -46,6 +52,7 @@ _QUERY_SCHEMA: Final = vol.Schema(
 PLATFORM_SCHEMA: Final = BINARY_SENSOR_PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_URL, default=DEFAULT_URL): cv.string,
+        vol.Optional(CONF_HEADERS): vol.Schema({cv.string: cv.string}),
         vol.Required(CONF_QUERIES): [_QUERY_SCHEMA],
     }
 )
@@ -60,7 +67,8 @@ async def async_setup_platform(
     """Set up the sensor platform."""
     session = async_get_clientsession(hass)
     url = config[CONF_URL]
-    prometheus = Prometheus(url, session)
+    headers = config.get(CONF_HEADERS)
+    prometheus = Prometheus(url, session, headers)
 
     async_add_entities(
         new_entities=[

--- a/custom_components/prometheus_sensor/const.py
+++ b/custom_components/prometheus_sensor/const.py
@@ -11,3 +11,4 @@ DEFAULT_URL: Final = "http://localhost:9090"
 
 CONF_QUERIES: Final = "queries"
 CONF_EXPR: Final = "expr"
+CONF_HEADERS: Final = "headers"

--- a/custom_components/prometheus_sensor/sensor.py
+++ b/custom_components/prometheus_sensor/sensor.py
@@ -32,7 +32,13 @@ if TYPE_CHECKING:
 
     from . import QueryResult
 
-from .const import CONF_EXPR, CONF_QUERIES, DEFAULT_URL, SCAN_INTERVAL as SCAN_INTERVAL
+from .const import (
+    CONF_EXPR,
+    CONF_HEADERS,
+    CONF_QUERIES,
+    DEFAULT_URL,
+    SCAN_INTERVAL as SCAN_INTERVAL,
+)
 
 _QUERY_SCHEMA: Final = vol.Schema(
     {
@@ -48,6 +54,7 @@ _QUERY_SCHEMA: Final = vol.Schema(
 PLATFORM_SCHEMA: Final = SENSOR_PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_URL, default=DEFAULT_URL): cv.string,
+        vol.Optional(CONF_HEADERS): vol.Schema({cv.string: cv.string}),
         vol.Required(CONF_QUERIES): [_QUERY_SCHEMA],
     }
 )
@@ -62,7 +69,8 @@ async def async_setup_platform(
     """Set up the sensor platform."""
     session = async_get_clientsession(hass)
     url = config[CONF_URL]
-    prometheus = Prometheus(url, session)
+    headers = config.get(CONF_HEADERS)
+    prometheus = Prometheus(url, session, headers)
 
     async_add_entities(
         new_entities=[


### PR DESCRIPTION
Hello!

I'm using Mimir instead of Prometheus, which supports multi-tenancy and needs the X-Scope-OrgID header set. This adds the ability to add headers